### PR TITLE
Dependabot integration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+- package-ecosystem: pip
+  directory: "/lambda/source"
+  schedule:
+    interval: daily
+    time: '08:00'
+  open-pull-requests-limit: 99
+  allow:
+  - dependency-type: direct
+  - dependency-type: indirect
+- package-ecosystem: terraform
+  directory: "/lambda"
+  schedule:
+    interval: daily
+    time: '08:00'
+  open-pull-requests-limit: 99


### PR DESCRIPTION
This pull request adds Dependabot scans to the project

Dependabot scans project requirements files (in this case `requirements.txt` and `lambda.tf`) and checks if they are up to date.

When a package is outdated it creates a PR with the updated version, so the users just need to review and aprove.